### PR TITLE
Switch to Django 2.0.8 due to security vuln

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==2
+Django==2.0.8
 pytest


### PR DESCRIPTION
Django 2.0 has security vulnerabilities as per:
https://nvd.nist.gov/vuln/detail/CVE-2018-6188
https://nvd.nist.gov/vuln/detail/CVE-2018-14574